### PR TITLE
Fix MML mime generation + other stuff

### DIFF
--- a/himalaya.el
+++ b/himalaya.el
@@ -440,6 +440,30 @@ If called with \\[universal-argument], message will be REPLY-ALL."
     (insert template))
   (himalaya--prepare-email-write-buffer (current-buffer)))
 
+(defun himalaya-message-reply ()
+  "Reply to the message at point."
+  (interactive)
+  (let* ((message (tabulated-list-get-entry))
+         (uid (substring-no-properties (elt message 0))))
+    (setq himalaya-uid uid)
+    (himalaya-message-read-reply)))
+
+(defun himalaya-message-reply-all ()
+  "Reply all to the message at point."
+  (interactive)
+  (let* ((message (tabulated-list-get-entry))
+         (uid (substring-no-properties (elt message 0))))
+    (setq himalaya-uid uid)
+    (himalaya-message-read-reply t)))
+
+(defun himalaya-message-forward ()
+  "Forward the message at point."
+  (interactive)
+  (let* ((message (tabulated-list-get-entry))
+         (uid (substring-no-properties (elt message 0))))
+    (setq himalaya-uid uid)
+    (himalaya-message-read-forward)))
+
 (defun himalaya-message-select ()
   "Read the message at point."
   (interactive)
@@ -516,6 +540,9 @@ If called with \\[universal-argument], message will be REPLY-ALL."
     (define-key map (kbd "M") #'himalaya-message-move)
     (define-key map (kbd "D") #'himalaya-message-delete)
     (define-key map (kbd "w") #'himalaya-message-write)
+    (define-key map (kbd "r") #'himalaya-message-reply)
+    (define-key map (kbd "R") #'himalaya-message-reply-all)
+    (define-key map (kbd "F") #'himalaya-message-forward)
     map))
 
 (define-derived-mode himalaya-message-list-mode tabulated-list-mode "Himylaya-Messages"

--- a/himalaya.el
+++ b/himalaya.el
@@ -222,11 +222,11 @@ non-nil, return the raw contents of the email including headers.
 If HTML is non-nil, return the HTML version of the email,
 otherwise return the plain text version."
   (himalaya--run-json (when account (list "-a" account))
-                      (when mailbox (list "-m" mailbox))
-                      "read"
+		      (when mailbox (list "-m" mailbox))
+		      "read"
 		      (format "%s" uid) ; Ensure uid is a string
-                      (when raw "-r")
-                      (when html (list "-t" "html"))
+		      (when raw "-r")
+		      (when html (list "-t" "html"))
 		      (list "-h" "from" "to" "cc" "bcc" "subject" "date")))
 
 (defun himalaya--message-copy (uid target &optional account mailbox)

--- a/himalaya.el
+++ b/himalaya.el
@@ -388,7 +388,8 @@ If ACCOUNT or MAILBOX are nil, use the defaults."
       (insert (propertize "Date: " 'face himalaya-headers-face)
               (alist-get 'date headers) "\n")
       (insert "\n")
-      (insert message))
+      (insert message)
+      (goto-char (point-min)))
     (himalaya-message-read-mode)
     (setq himalaya-account account)
     (setq himalaya-mailbox mailbox)
@@ -449,7 +450,7 @@ If called with \\[universal-argument], message will be REPLY-ALL."
   "Open a new bugger for writing a message."
   (interactive)
   (let ((template (himalaya--template-new himalaya-account)))
-    (switch-to-buffer (generate-new-buffer "*Himalaya New Email*"))
+    (switch-to-buffer (generate-new-buffer "*Himalaya New Message*"))
     (insert template))
   (himalaya--prepare-email-write-buffer (current-buffer)))
 
@@ -481,7 +482,7 @@ If called with \\[universal-argument], message will be REPLY-ALL."
   (let* ((message (tabulated-list-get-entry))
          (uid (substring-no-properties (elt message 0)))
          (subject (substring-no-properties (elt message 2))))
-    (when (y-or-n-p (format "Delete email \"%s\"? " subject))
+    (when (y-or-n-p (format "Delete message \"%s\"? " subject))
       (himalaya--message-delete (list uid))
       (revert-buffer))))
 

--- a/himalaya.el
+++ b/himalaya.el
@@ -192,9 +192,7 @@ Sets the mail function correctly, adds mail header, etc."
     (forward-line)
     (message-mode)
     ;; We do a little hacking
-    (make-local-variable 'message-send-method-alist)
-    (setq message-send-method-alist
-          '((mail message-mail-p himalaya-send-buffer)))))
+    (setq-local message-send-mail-real-function 'himalaya-send-buffer)))
 
 (defun himalaya--mailbox-list (&optional account)
   "Return a list of mailboxes for ACCOUNT.


### PR DESCRIPTION
I started to dig a bit this issue https://github.com/soywod/himalaya/issues/142#issuecomment-1030408182. I found out that it was related to the [MML](https://www.gnu.org/software/emacs/manual/html_node/emacs-mime/MML-Definition.html) module. Then I found the function `mml-generate-mime`:

```help
mml-generate-mime is a compiled Lisp function in ‘mml.el’.

(mml-generate-mime &optional MULTIPART-TYPE CONTENT-TYPE)

Generate a MIME message based on the current MML document.
MULTIPART-TYPE defaults to "mixed", but can also
be "related" or "alternate".
```

By replacing the `message-send-method`, you skip the call of `mml-generate-mime` from `message-send-mail` and the MML is sent raw. I found a function `message-send-mail-real-function` that is used (if defined) just AFTER the MML generation. I did some tests and it seems to work well!

I also:

- renamed some wordings (email to message, in order to be consistent with the CLI and the Vim plugin)
- fixed bad decoding #2 (needs CLI built on the `development` branch, I should release soon the next version)
- added the reply, reply all and forward on the list view #1 