### PR TITLE
Add `C-u g` keybind to reset pagination

### DIFF
--- a/himalaya.el
+++ b/himalaya.el
@@ -430,6 +430,7 @@ If called with \\[universal-argument], message will be REPLY-ALL."
   (let ((template (himalaya--template-reply himalaya-uid himalaya-account himalaya-mailbox reply-all)))
     (switch-to-buffer (generate-new-buffer (format "*Reply: %s*" himalaya-subject)))
     (insert template)
+    (set-buffer-modified-p nil)
     (himalaya--prepare-email-write-buffer (current-buffer))))
 
 (defun himalaya-message-read-forward ()
@@ -438,6 +439,7 @@ If called with \\[universal-argument], message will be REPLY-ALL."
   (let ((template (himalaya--template-forward himalaya-uid himalaya-account himalaya-mailbox)))
     (switch-to-buffer (generate-new-buffer (format "*Forward: %s*" himalaya-subject)))
     (insert template)
+    (set-buffer-modified-p nil)
     (himalaya--prepare-email-write-buffer (current-buffer))))
 
 (defun himalaya-message-write ()
@@ -445,8 +447,9 @@ If called with \\[universal-argument], message will be REPLY-ALL."
   (interactive)
   (let ((template (himalaya--template-new himalaya-account)))
     (switch-to-buffer (generate-new-buffer "*Himalaya New Message*"))
-    (insert template))
-  (himalaya--prepare-email-write-buffer (current-buffer)))
+    (insert template)
+    (set-buffer-modified-p nil)
+    (himalaya--prepare-email-write-buffer (current-buffer))))
 
 (defun himalaya-message-reply (&optional reply-all)
   "Reply to the message at point.

--- a/himalaya.el
+++ b/himalaya.el
@@ -187,7 +187,7 @@ The result is parsed as JSON and returned."
   "Setup BUFFER to be used to write an email.
 Sets the mail function correctly, adds mail header, etc."
   (with-current-buffer buffer
-    (goto-line 1)
+    (goto-char (point-min))
     (search-forward "\n\n")
     (forward-line -1)
     (insert mail-header-separator)
@@ -328,7 +328,7 @@ Processes the buffer to replace \n with \r\n and removes `mail-header-separator'
   "Construct the message list table."
   (when (consp current-prefix-arg)
     (setq himalaya-page 1)
-    (goto-line 1))
+    (goto-char (point-min)))
   (let ((messages (himalaya--message-list himalaya-account himalaya-mailbox himalaya-page))
         entries)
     (dolist (message messages entries)
@@ -382,7 +382,7 @@ If ACCOUNT or MAILBOX are nil, use the defaults."
     (insert message)
     (set-buffer-modified-p nil)
     (himalaya-message-read-mode)
-    (goto-line 1)
+    (goto-char (point-min))
     (setq buffer-read-only t)
     (setq himalaya-account account)
     (setq himalaya-mailbox mailbox)

--- a/himalaya.el
+++ b/himalaya.el
@@ -181,19 +181,19 @@ The result is parsed as JSON and returned."
   "Extract email headers from MESSAGE."
   (with-temp-buffer
     (insert message)
-    (goto-char (point-min))
     (mail-header-extract-no-properties)))
 
 (defun himalaya--prepare-email-write-buffer (buffer)
   "Setup BUFFER to be used to write an email.
 Sets the mail function correctly, adds mail header, etc."
   (with-current-buffer buffer
-    (goto-char (point-min))
+    (goto-line 1)
     (search-forward "\n\n")
     (forward-line -1)
     (insert mail-header-separator)
     (forward-line)
     (message-mode)
+    (set-buffer-modified-p nil)
     ;; We do a little hacking
     (setq-local message-send-mail-real-function 'himalaya-send-buffer)))
 
@@ -326,6 +326,9 @@ Processes the buffer to replace \n with \r\n and removes `mail-header-separator'
 
 (defun himalaya--message-list-build-table ()
   "Construct the message list table."
+  (when (consp current-prefix-arg)
+    (setq himalaya-page 1)
+    (goto-line 1))
   (let ((messages (himalaya--message-list himalaya-account himalaya-mailbox himalaya-page))
         entries)
     (dolist (message messages entries)
@@ -379,7 +382,7 @@ If ACCOUNT or MAILBOX are nil, use the defaults."
     (insert message)
     (set-buffer-modified-p nil)
     (himalaya-message-read-mode)
-    (goto-char (point-min))
+    (goto-line 1)
     (setq buffer-read-only t)
     (setq himalaya-account account)
     (setq himalaya-mailbox mailbox)
@@ -478,7 +481,8 @@ If called with \\[universal-argument], message will be REPLY-ALL."
   (interactive (list (completing-read "Copy to mailbox: " (himalaya--mailbox-list-names himalaya-account))))
   (let* ((message (tabulated-list-get-entry))
          (uid (substring-no-properties (elt message 0))))
-    (message "%s" (himalaya--message-copy uid target himalaya-account himalaya-mailbox))))
+    (message "%s" (himalaya--message-copy uid target himalaya-account himalaya-mailbox))
+    (revert-buffer)))
 
 (defun himalaya-message-move (target)
   "Move the message at point to TARGET mailbox."


### PR DESCRIPTION
Fixes #6.

In fact the keybind `g` is managed by the tabulated-list plugin, so I was not able to change it. But I propose to use the `C-u` prefix instead: if a prefix is found (`C-u g`), it will reset the pagination and scroll to top, otherwise (`g`) it will just refresh without touching the pagination and the scroll. Let me know what you think about this addition!