### PR TITLE
Add mark support for attachments, copy, move and delete commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2] - 2022-12-21
-
 ### Added
 
 * Included code from a [fork](https://git.sr.ht/~soywod/himalaya-emacs) [#15].
@@ -21,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * Fixed `nil` subjects in read buffers.
+* Fixed `Answered` flag not set after replying to an email.
 
 ## [0.1] - 2022-10-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Included code from a [fork](https://git.sr.ht/~soywod/himalaya-emacs) [#15].
-* Added copy, move and delete many emails using marks (inspired by the
-  [tablist](https://github.com/politza/tablist) package).
+* Added possibility to mark multiple emails. Compatible actions:
+  attachments, copy, move and delete. The implementation was inspired
+  by the [tablist](https://github.com/politza/tablist) package) [#17].
 
 ### Changed
 
@@ -32,3 +33,4 @@ First plugin release to be added to the
 [0.1]: https://github.com/dantecatalfamo/himalaya-emacs/releases/tag/v0.1
 
 [#15]: https://github.com/dantecatalfamo/himalaya-emacs/pull/15
+[#17]: https://github.com/dantecatalfamo/himalaya-emacs/pull/17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Included code from a [fork](https://git.sr.ht/~soywod/himalaya-emacs) [#15].
+* Added copy, move and delete many emails using marks (inspired by the
+  [tablist](https://github.com/politza/tablist) package).
 
 ### Changed
 

--- a/README.org
+++ b/README.org
@@ -27,46 +27,52 @@
    Most settings can be customized through the Emacs Easy Customize
    system. =M-x customize-group himalaya=
 
-** List Messages
+** List emails
 
-   =M-x himalaya= or =M-x himalaya-message-list=
+   =M-x himalaya= or =M-x himalaya-email-list=
 
-   | Key   | Action           |
-   |-------+------------------|
-   | =n=   | Move cursor down |
-   | =p=   | Move cursor up   |
-   | =f=   | Forward page     |
-   | =b=   | Backwards page   |
-   | =j=   | Jump to page     |
-   | =m=   | Switch mailbox   |
-   | =R=   | Reply to message |
-   | =F=   | Forward message  |
-   | =w=   | Write message    |
-   | =C=   | Copy message     |
-   | =M=   | Move message     |
-   | =D=   | Delete message   |
-   | =RET= | View message     |
+   | Key     | Action                                                  |
+   |---------+---------------------------------------------------------|
+   | =n=     | Move cursor down                                        |
+   | =p=     | Move cursor up                                          |
+   | =m=     | Mark email at cursor                                    |
+   | =u=     | Unmark email at cursor                                  |
+   | =DEL=   | Unmark email at cursor (backward)                       |
+   | =U=     | Unmark all emails                                       |
+   | =f=     | Forward page                                            |
+   | =b=     | Backward page                                           |
+   | =j=     | Jump to page                                            |
+   | =C-c f= | Switch folder                                           |
+   | =R=     | Reply to email at cursor                                |
+   | =F=     | Forward email at cursor                                 |
+   | =w=     | Write new email                                         |
+   | =a=     | Download marked emails (or email at cursor) attachments |
+   | =C=     | Copy marked emails (or email at cursor)                 |
+   | =M=     | Move marked emails (or email at cursor)                 |
+   | =D=     | Delete marked emails (or email at cursor)               |
+   | =RET=   | Read email at cursor                                    |
 
-** Read Message
+** Read email
 
-   After pressing enter on a message, you'll enter the message viewing
+   After pressing enter on an email, you'll enter the email viewing
    mode.
 
    | Key | Action               |
    |-----+----------------------|
    | =a= | Download attachments |
-   | =n= | Next message         |
-   | =p= | Previous message     |
-   | =r= | Reply to message     |
-   | =f= | Forward message      |
-   | =R= | View raw message     |
+   | =n= | Next email           |
+   | =p= | Previous email       |
+   | =r= | Reply to email       |
+   | =f= | Forward email        |
+   | =R= | View raw email       |
    | =q= | Kill buffer          |
 
-** Reply All
+** Reply all
+
    Pressing the universal argument key (=C-u= by default) before
-   pressing the reply key will reply all to a message.
+   pressing the reply key will reply all to an email.
 
-** Write Message
+** Write new email
 
-   When writing a new message or a reply, press =C-c C-c= to send it
-   or =C-c C-k= to delete it.
+   When writing a new email or a reply, press =C-c C-c= to send it or
+   =C-c C-k= to delete it.

--- a/himalaya.el
+++ b/himalaya.el
@@ -243,23 +243,23 @@ otherwise return the plain text version."
 		      (when html (list "-t" "html"))
 		      (list "-H" "From" "-H" "To" "-H" "Cc" "-H" "Bcc" "-H" "Subject" "-H" "Date")))
 
-(defun himalaya--email-copy (ids target &optional account folder)
+(defun himalaya--email-copy (target ids &optional account folder)
   "Copy email with ID from FOLDER to TARGET folder on ACCOUNT.
 If ACCOUNT or FOLDER are nil, use the defaults."
   (himalaya--run-json (when account (list "-a" account))
                       (when folder (list "-f" folder))
                       "copy"
                       target
-                      (mapconcat 'identity ids ",")))
+                      ids))
 
-(defun himalaya--email-move (ids target &optional account folder)
+(defun himalaya--email-move (target ids &optional account folder)
   "Move email with ID from FOLDER to TARGET folder on ACCOUNT.
 If ACCOUNT or FOLDER are nil, use the defaults."
   (himalaya--run-json (when account (list "-a" account))
                       (when folder (list "-f" folder))
                       "move"
                       target
-                      (mapconcat 'identity ids ",")))
+                      ids))
 
 (defun himalaya--email-delete (ids &optional account folder)
   "Delete emails with IDS from FOLDER on ACCOUNT.
@@ -268,7 +268,7 @@ IDS is a list of numbers."
   (himalaya--run-json (when account (list "-a" account))
                       (when folder (list "-f" folder))
                       "delete"
-                      (mapconcat 'identity ids ",")))
+		      ids))
 
 (defun himalaya--email-attachments (id &optional account folder)
   "Download attachments from email with ID.
@@ -327,6 +327,7 @@ If ACCOUNT or FOLDER are nil, the defaults are used."
    "flags"
    "add"
    id
+   "--"
    flags))
 
 (defun himalaya-send-buffer (&rest _)
@@ -578,8 +579,8 @@ If called with \\[universal-argument], email will be REPLY-ALL."
 TARGET folder."
   (interactive (list (completing-read "Copy to folder: " (himalaya--folder-list-names himalaya-account))))
   (if (not himalaya-marked-ids)
-      (message "%s" (himalaya--email-copy (list (tabulated-list-get-id)) target himalaya-account himalaya-folder))
-    (message "%s" (himalaya--email-copy himalaya-marked-ids target himalaya-account himalaya-folder))
+      (message "%s" (himalaya--email-copy target (list (tabulated-list-get-id)) himalaya-account himalaya-folder))
+    (message "%s" (himalaya--email-copy target himalaya-marked-ids himalaya-account himalaya-folder))
     (himalaya-unmark-all t))
   (revert-buffer))
 
@@ -588,8 +589,8 @@ TARGET folder."
 TARGET folder."
   (interactive (list (completing-read "Move to folder: " (himalaya--folder-list-names himalaya-account))))
   (if (not himalaya-marked-ids)
-      (message "%s" (himalaya--email-move (list (tabulated-list-get-id)) target himalaya-account himalaya-folder))
-    (message "%s" (himalaya--email-move himalaya-marked-ids target himalaya-account himalaya-folder))
+      (message "%s" (himalaya--email-move target (list (tabulated-list-get-id)) himalaya-account himalaya-folder))
+    (message "%s" (himalaya--email-move target himalaya-marked-ids himalaya-account himalaya-folder))
     (himalaya-unmark-all t))
   (revert-buffer))
 
@@ -601,11 +602,11 @@ TARGET folder."
          (subject (substring-no-properties (elt email 2))))
     (if himalaya-marked-ids
 	(when (y-or-n-p (format "Delete emails %s? " (string-join himalaya-marked-ids ", ")))
-	  (message "%s" (himalaya--email-delete himalaya-marked-ids))
-	  (himalaya-unmark-all)
+	  (message "%s" (himalaya--email-delete himalaya-marked-ids himalaya-account himalaya-folder))
+	  (himalaya-unmark-all t)
 	  (revert-buffer))	
       (when (y-or-n-p (format "Delete email %s? " subject))
-	(message "%s" (himalaya--email-delete (list id)))
+	(message "%s" (himalaya--email-delete (list id) himalaya-account himalaya-folder))
 	(revert-buffer)))))
 
 (defun himalaya-forward-page ()

--- a/himalaya.el
+++ b/himalaya.el
@@ -249,8 +249,8 @@ If ACCOUNT or FOLDER are nil, use the defaults."
   (himalaya--run-json (when account (list "-a" account))
                       (when folder (list "-f" folder))
                       "copy"
-		      target
-		      (mapconcat 'identity ids ",")))
+                      target
+                      (mapconcat 'identity ids ",")))
 
 (defun himalaya--email-move (ids target &optional account folder)
   "Move email with ID from FOLDER to TARGET folder on ACCOUNT.
@@ -258,8 +258,8 @@ If ACCOUNT or FOLDER are nil, use the defaults."
   (himalaya--run-json (when account (list "-a" account))
                       (when folder (list "-f" folder))
                       "move"
-		      target
-		      (mapconcat 'identity ids ",")))
+                      target
+                      (mapconcat 'identity ids ",")))
 
 (defun himalaya--email-delete (ids &optional account folder)
   "Delete emails with IDS from FOLDER on ACCOUNT.
@@ -268,7 +268,7 @@ IDS is a list of numbers."
   (himalaya--run-json (when account (list "-a" account))
                       (when folder (list "-f" folder))
                       "delete"
-		      (mapconcat 'identity ids ",")))
+                      (mapconcat 'identity ids ",")))
 
 (defun himalaya--email-attachments (id &optional account folder)
   "Download attachments from email with ID.
@@ -597,7 +597,7 @@ TARGET folder."
   "Delete marked emails (or the email at point if no mark exist)."
   (interactive)
   (let* ((email (tabulated-list-get-entry))
-	 (id (tabulated-list-get-id))
+         (id (tabulated-list-get-id))
          (subject (substring-no-properties (elt email 2))))
     (if himalaya-marked-ids
 	(when (y-or-n-p (format "Delete emails %s? " (string-join himalaya-marked-ids ", ")))

--- a/himalaya.el
+++ b/himalaya.el
@@ -129,17 +129,18 @@
   :group 'himalaya)
 
 
+(defvar himalaya-id nil
+  "The current email id.")
+
+(defvar himalaya-reply nil
+  "True if the current email is a reply.")
+
+
 (defvar-local himalaya-folder nil
   "The current folder.")
 
 (defvar-local himalaya-account nil
   "The current account.")
-
-(defvar-local himalaya-id nil
-  "The current email id.")
-
-(defvar-local himalaya-reply nil
-  "True if the current message is a reply.")
 
 (defvar-local himalaya-subject nil
   "The current email subject.")

--- a/himalaya.el
+++ b/himalaya.el
@@ -268,15 +268,15 @@ IDS is a list of numbers."
   (himalaya--run-json (when account (list "-a" account))
                       (when folder (list "-f" folder))
                       "delete"
-		      ids))
+                      ids))
 
-(defun himalaya--email-attachments (id &optional account folder)
+(defun himalaya--email-attachments (ids &optional account folder)
   "Download attachments from email with ID.
 If ACCOUNT or FOLDER are nil, use the defaults."
   (himalaya--run-json (when account (list "-a" account))
                       (when folder (list "-f" folder))
                       "attachments"
-                      (format "%s" id)))
+                      ids))
 
 (defun himalaya--template-new (&optional account)
   "Return a template for a new email from ACCOUNT."
@@ -511,9 +511,10 @@ If ACCOUNT or FOLDER are nil, use the defaults."
     (kill-buffer buf)))
 
 (defun himalaya-email-read-download-attachments ()
-  "Download any attachments on the current email."
+  "Download all attachments of current email."
   (interactive)
-  (email (himalaya--email-attachments himalaya-id himalaya-account himalaya-folder)))
+  (message "Fetching attachments…")
+  (message "%s" (himalaya--email-attachments (list himalaya-id) himalaya-account himalaya-folder)))
 
 (defun himalaya-email-read-reply (&optional reply-all)
   "Open a new buffer with a reply template to the current email.
@@ -574,6 +575,16 @@ If called with \\[universal-argument], email will be REPLY-ALL."
          (id (substring-no-properties (elt email 0))))
     (himalaya-email-read id himalaya-account himalaya-folder)))
 
+(defun himalaya-email-download-attachments ()
+  "Download marked emails attachments (or the email at point if no
+mark exist)."
+  (interactive)
+  (message "Fetching attachments…")
+  (if (not himalaya-marked-ids)
+      (message "%s" (himalaya--email-attachments (list (tabulated-list-get-id)) himalaya-account himalaya-folder))
+    (message "%s" (himalaya--email-attachments himalaya-marked-ids himalaya-account himalaya-folder))
+    (himalaya-unmark-all t)))
+
 (defun himalaya-email-copy (target)
   "Copy marked emails (or the email at point if no mark exist) to
 TARGET folder."
@@ -595,7 +606,8 @@ TARGET folder."
   (revert-buffer))
 
 (defun himalaya-email-delete ()
-  "Delete marked emails (or the email at point if no mark exist)."
+  "Delete marked emails (or the email at point if no mark
+exist)."
   (interactive)
   (let* ((email (tabulated-list-get-entry))
          (id (tabulated-list-get-id))
@@ -655,6 +667,7 @@ TARGET folder."
     (define-key map (kbd "f") #'himalaya-forward-page)
     (define-key map (kbd "b") #'himalaya-backward-page)
     (define-key map (kbd "j") #'himalaya-jump-to-page)
+    (define-key map (kbd "a") #'himalaya-email-download-attachments)
     (define-key map (kbd "C") #'himalaya-email-copy)
     (define-key map (kbd "M") #'himalaya-email-move)
     (define-key map (kbd "D") #'himalaya-email-delete)


### PR DESCRIPTION
This feature allows users to mark emails on the list view (like dired: `m` to mark, `u` to unmark, `DEL` to unmark backward and `U` to unmark all) and to trigger actions on those marked emails (attachments, copy, move and delete). I took inspiration from the great package [tablist](https://github.com/politza/tablist).