### PR TITLE
Prepare code for `v1.0.0-beta.4`

### DIFF
--- a/README.org
+++ b/README.org
@@ -31,32 +31,35 @@
 
    =M-x himalaya= or =M-x himalaya-list-envelopes=
 
-   | Key     | Action                                                      |
-   |---------+-------------------------------------------------------------|
-   | =n=     | Move cursor down                                            |
-   | =p=     | Move cursor up                                              |
-   | =m=     | Mark envelope at cursor                                     |
-   | =u=     | Unmark envelope at cursor                                   |
-   | =DEL=   | Unmark envelope at cursor (backward)                        |
-   | =U=     | Unmark all envelopes                                        |
-   | =f=     | Forward page                                                |
-   | =b=     | Backward page                                               |
-   | =j=     | Jump to page                                                |
-   | =C-c a= | Switch account                                              |
-   | =C-c f= | Switch folder                                               |
-   | =C-c += | Add flag to marked envelopes (or envelope at point)         |
-   | =C-c -= | Remove flag from marked envelopes (or envelope at point)    |
-   | =R=     | Reply to message at cursor                                  |
-   | =F=     | Forward message at cursor                                   |
-   | =w=     | Write new message                                           |
-   | =a=     | Download marked messages (or message at cursor) attachments |
-   | =s=     | Synchronize current account                                 |
-   | =C=     | Copy marked messages (or message at cursor)                 |
-   | =M=     | Move marked messages (or message at cursor)                 |
-   | =D=     | Delete marked messages (or message at cursor)               |
-   | =e=     | Expunge current folder                                      |
-   | =RET=   | Read message at cursor                                      |
+   | Key       | Action                                                      |
+   |-----------+-------------------------------------------------------------|
+   | =n=       | Move cursor down                                            |
+   | =p=       | Move cursor up                                              |
+   | =m=       | Mark envelope at cursor                                     |
+   | =u=       | Unmark envelope at cursor                                   |
+   | =DEL=     | Unmark envelope at cursor (backward)                        |
+   | =U=       | Unmark all envelopes                                        |
+   | =f=       | Forward page                                                |
+   | =b=       | Backward page                                               |
+   | =j=       | Jump to page                                                |
+   | =C-c C-s= | Filter and sort query according to the given query          |
+   | =C-c a=   | Switch account                                              |
+   | =C-c f=   | Switch folder                                               |
+   | =C-c +=   | Add flag to marked envelopes (or envelope at point)         |
+   | =C-c -=   | Remove flag from marked envelopes (or envelope at point)    |
+   | =R=       | Reply to message at cursor                                  |
+   | =F=       | Forward message at cursor                                   |
+   | =w=       | Write new message                                           |
+   | =a=       | Download marked messages (or message at cursor) attachments |
+   | =s=       | Synchronize current account                                 |
+   | =C=       | Copy marked messages (or message at cursor)                 |
+   | =M=       | Move marked messages (or message at cursor)                 |
+   | =D=       | Delete marked messages (or message at cursor)               |
+   | =e=       | Expunge current folder                                      |
+   | =RET=     | Read message at cursor                                      |
 
+   See the [[https://pimalaya.org/himalaya/cli/latest/usage/advanced/envelope/list.html#query][documentation]] for more detailed information about the query API.
+   
 ** Read message
 
    After pressing enter on an envelope, you'll enter the message
@@ -90,4 +93,4 @@
    that helped the project to receive financial support from:
 
    - [[https://nlnet.nl/assure/][NGI Assure]] in 2022
-   - [[https://nlnet.nl/entrust/][NGI Zero Untrust]] in 2023
+   - [[https://nlnet.nl/entrust/][NGI Zero Entrust]] in 2023

--- a/README.org
+++ b/README.org
@@ -1,7 +1,7 @@
 * Himalaya Emacs
   [[https://melpa.org/#/himalaya][file:https://melpa.org/packages/himalaya-badge.svg]]
 
-  Emacs front-end for the email client [[https://github.com/soywod/himalaya][Himalaya CLI]].
+  Emacs front-end for the email client [[https://github.com/pimalaya/himalaya][Himalaya CLI]].
 
 ** Installation
 

--- a/himalaya-account.el
+++ b/himalaya-account.el
@@ -1,7 +1,7 @@
 ;;; himalaya-account.el --- Account management of email client Himalaya CLI  -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2021 Dante Catalfamo
-;; Copyright (C) 2022-2023 soywod <clement.douin@posteo.net>
+;; Copyright (C) 2022-2024 soywod <clement.douin@posteo.net>
 
 ;; Author: Dante Catalfamo
 ;;      soywod <clement.douin@posteo.net>

--- a/himalaya-attachment.el
+++ b/himalaya-attachment.el
@@ -1,7 +1,7 @@
 ;;; himalaya-attachment.el --- Attachment management of email client Himalaya CLI  -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2021 Dante Catalfamo
-;; Copyright (C) 2022-2023 soywod <clement.douin@posteo.net>
+;; Copyright (C) 2022-2024 soywod <clement.douin@posteo.net>
 
 ;; Author: Dante Catalfamo
 ;;      soywod <clement.douin@posteo.net>

--- a/himalaya-envelope-mark.el
+++ b/himalaya-envelope-mark.el
@@ -1,7 +1,7 @@
 ;;; himalaya-envelope-mark.el --- Envelope marks management of email client Himalaya CLI  -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2021 Dante Catalfamo
-;; Copyright (C) 2022-2023 soywod <clement.douin@posteo.net>
+;; Copyright (C) 2022-2024 soywod <clement.douin@posteo.net>
 
 ;; Author: Dante Catalfamo
 ;;      soywod <clement.douin@posteo.net>

--- a/himalaya-envelope.el
+++ b/himalaya-envelope.el
@@ -94,6 +94,9 @@
 (defvar himalaya-page 1
   "The current envelope list page.")
 
+(defvar himalaya-list-envelopes-query nil
+  "The current list envelopes filter and sort query.")
+
 (defun himalaya--list-envelopes ()
   "Fetch envelopes from the current account in the current
 folder. Paginate using the current page of global page size. This
@@ -102,10 +105,11 @@ which cannot work with callbacks."
   (himalaya--run-blocking
    "envelope"
    "list"
+   (when himalaya-folder (list "--folder" himalaya-folder))
    (when himalaya-account (list "--account" himalaya-account))
    (when himalaya-page (list "--page" (format "%s" himalaya-page)))
    (when himalaya-list-envelopes-page-size (list "--page-size" (prin1-to-string himalaya-list-envelopes-page-size)))
-   (when himalaya-folder himalaya-folder)))
+   (when himalaya-list-envelopes-query himalaya-list-envelopes-query)))
 
 (defun himalaya--build-envelopes-table ()
   "Build the envelopes table."
@@ -155,29 +159,38 @@ which cannot work with callbacks."
   (himalaya--update-mode-line)
   (revert-buffer))
 
+(defun himalaya-filter-and-sort-envelopes (query)
+  "Filter and sort envelopes of the current folder matching the
+given QUERY."
+  (interactive "MQuery: ")
+  (setq himalaya-list-envelopes-query (if (string-empty-p query) nil query))
+  (himalaya--update-mode-line)
+  (revert-buffer))
+
 (defvar himalaya-list-envelopes-mode-map
   (let ((map (make-sparse-keymap)))
-    (define-key map (kbd "C-c a") #'himalaya-switch-account)
-    (define-key map (kbd "s"    ) #'himalaya-sync-account)
-    (define-key map (kbd "C-c f") #'himalaya-switch-folder)
-    (define-key map (kbd "e"    ) #'himalaya-expunge-folder)
-    (define-key map (kbd "f"    ) #'himalaya-list-envelopes-next-page)
-    (define-key map (kbd "b"    ) #'himalaya-list-envelopes-prev-page)
-    (define-key map (kbd "j"    ) #'himalaya-list-envelopes-at-page)
-    (define-key map (kbd "m"    ) #'himalaya-mark-envelope-forward)
-    (define-key map (kbd "DEL"  ) #'himalaya-unmark-envelope-backward)
-    (define-key map (kbd "u"    ) #'himalaya-unmark-envelope-forward)
-    (define-key map (kbd "U"    ) #'himalaya-unmark-all-envelopes)
-    (define-key map (kbd "C-c +") #'himalaya-add-flag-marked-envelopes)
-    (define-key map (kbd "C-c -") #'himalaya-remove-flag-marked-envelopes)
-    (define-key map (kbd "RET"  ) #'himalaya-read-message-at-point)
-    (define-key map (kbd "w"    ) #'himalaya-write-new-message)
-    (define-key map (kbd "R"    ) #'himalaya-reply-to-message-at-point)
-    (define-key map (kbd "F"    ) #'himalaya-forward-message-at-point)
-    (define-key map (kbd "C"    ) #'himalaya-copy-marked-messages)
-    (define-key map (kbd "M"    ) #'himalaya-move-marked-messages)
-    (define-key map (kbd "D"    ) #'himalaya-delete-marked-messages)
-    (define-key map (kbd "a"    ) #'himalaya-download-marked-attachments)
+    (define-key map (kbd "C-c a"  ) #'himalaya-switch-account)
+    (define-key map (kbd "s"      ) #'himalaya-sync-account)
+    (define-key map (kbd "C-c f"  ) #'himalaya-switch-folder)
+    (define-key map (kbd "e"      ) #'himalaya-expunge-folder)
+    (define-key map (kbd "f"      ) #'himalaya-list-envelopes-next-page)
+    (define-key map (kbd "b"      ) #'himalaya-list-envelopes-prev-page)
+    (define-key map (kbd "j"      ) #'himalaya-list-envelopes-at-page)
+    (define-key map (kbd "C-c C-s") #'himalaya-filter-and-sort-envelopes)
+    (define-key map (kbd "m"      ) #'himalaya-mark-envelope-forward)
+    (define-key map (kbd "DEL"    ) #'himalaya-unmark-envelope-backward)
+    (define-key map (kbd "u"      ) #'himalaya-unmark-envelope-forward)
+    (define-key map (kbd "U"      ) #'himalaya-unmark-all-envelopes)
+    (define-key map (kbd "C-c +"  ) #'himalaya-add-flag-marked-envelopes)
+    (define-key map (kbd "C-c -"  ) #'himalaya-remove-flag-marked-envelopes)
+    (define-key map (kbd "RET"    ) #'himalaya-read-message-at-point)
+    (define-key map (kbd "w"      ) #'himalaya-write-new-message)
+    (define-key map (kbd "R"      ) #'himalaya-reply-to-message-at-point)
+    (define-key map (kbd "F"      ) #'himalaya-forward-message-at-point)
+    (define-key map (kbd "C"      ) #'himalaya-copy-marked-messages)
+    (define-key map (kbd "M"      ) #'himalaya-move-marked-messages)
+    (define-key map (kbd "D"      ) #'himalaya-delete-marked-messages)
+    (define-key map (kbd "a"      ) #'himalaya-download-marked-attachments)
     map))
 
 (define-derived-mode himalaya-list-envelopes-mode tabulated-list-mode "Himalaya-Envelopes"

--- a/himalaya-envelope.el
+++ b/himalaya-envelope.el
@@ -1,7 +1,7 @@
 ;;; himalaya-envelope.el --- Envelope management of email client Himalaya CLI  -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2021 Dante Catalfamo
-;; Copyright (C) 2022-2023 soywod <clement.douin@posteo.net>
+;; Copyright (C) 2022-2024 soywod <clement.douin@posteo.net>
 
 ;; Author: Dante Catalfamo
 ;;      soywod <clement.douin@posteo.net>

--- a/himalaya-flag.el
+++ b/himalaya-flag.el
@@ -1,7 +1,7 @@
 ;;; himalaya-flag.el --- Flag management of email client Himalaya CLI  -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2021 Dante Catalfamo
-;; Copyright (C) 2022-2023 soywod <clement.douin@posteo.net>
+;; Copyright (C) 2022-2024 soywod <clement.douin@posteo.net>
 
 ;; Author: Dante Catalfamo
 ;;      soywod <clement.douin@posteo.net>

--- a/himalaya-folder.el
+++ b/himalaya-folder.el
@@ -1,7 +1,7 @@
 ;;; himalaya-folder.el --- Folder management for email client Himalaya CLI  -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2021 Dante Catalfamo
-;; Copyright (C) 2022-2023 soywod <clement.douin@posteo.net>
+;; Copyright (C) 2022-2024 soywod <clement.douin@posteo.net>
 
 ;; Author: Dante Catalfamo
 ;;      soywod <clement.douin@posteo.net>

--- a/himalaya-message.el
+++ b/himalaya-message.el
@@ -51,12 +51,12 @@
     (goto-char (point-min))
     (mail-header-extract-no-properties)))
 
-(defun himalaya--generate-write-buffer (buffer-name content)
+(defun himalaya--generate-write-buffer (buffer-name tpl)
   "Setup to be used to write a message."
   (switch-to-buffer (generate-new-buffer buffer-name))
-  (insert content)
-  (goto-char (point-min))
-  (search-forward "\n\n")
+  (insert (plist-get tpl :content))
+  (goto-line (plist-get (plist-get tpl :cursor) :row))
+  (move-to-column (plist-get (plist-get tpl :cursor) :col))
   (himalaya-message-write-mode)
   (set-buffer-modified-p nil))
 
@@ -320,7 +320,7 @@ point) from current folder of current account."
     (define-key map (kbd "R") #'himalaya-read-current-message-raw)
     (define-key map (kbd "r") #'himalaya-reply-to-current-message)
     (define-key map (kbd "f") #'himalaya-forward-current-message)
-    (define-key map (kbd "q") #'himalaya-kill-current-buffer-then-list-envelopes)
+    (define-key map (kbd "q") #'kill-current-buffer)
     (define-key map (kbd "n") #'himalaya-next-message)
     (define-key map (kbd "p") #'himalaya-prev-message)
     map))

--- a/himalaya-message.el
+++ b/himalaya-message.el
@@ -314,12 +314,6 @@ point) from current folder of current account."
        (set-buffer-modified-p nil)
        (kill-current-buffer)))))
 
-(defun himalaya-kill-current-buffer-then-list-envelopes ()
-  "Kill the current buffer then list envelopes."
-  (interactive)
-  (kill-current-buffer)
-  (himalaya-list-envelopes))
-
 (defvar himalaya-read-message-mode-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "a") #'himalaya-download-current-attachments)
@@ -341,7 +335,7 @@ point) from current folder of current account."
     (define-key map (kbd "R") #'himalaya-read-current-message-plain)
     (define-key map (kbd "r") #'himalaya-reply-to-current-message)
     (define-key map (kbd "f") #'himalaya-forward-current-message)
-    (define-key map (kbd "q") #'himalaya-kill-current-buffer-then-list-envelopes)
+    (define-key map (kbd "q") #'kill-current-buffer)
     (define-key map (kbd "n") #'himalaya-next-message)
     (define-key map (kbd "p") #'himalaya-prev-message)
     map))

--- a/himalaya-message.el
+++ b/himalaya-message.el
@@ -1,7 +1,7 @@
 ;;; himalaya-message.el --- Message management of email client Himalaya CLI  -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2021 Dante Catalfamo
-;; Copyright (C) 2022-2023 soywod <clement.douin@posteo.net>
+;; Copyright (C) 2022-2024 soywod <clement.douin@posteo.net>
 
 ;; Author: Dante Catalfamo
 ;;      soywod <clement.douin@posteo.net>

--- a/himalaya-process.el
+++ b/himalaya-process.el
@@ -1,7 +1,7 @@
 ;;; himalaya-process.el --- Process management of email client Himalaya CLI  -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2021 Dante Catalfamo
-;; Copyright (C) 2022-2023 soywod <clement.douin@posteo.net>
+;; Copyright (C) 2022-2024 soywod <clement.douin@posteo.net>
 
 ;; Author: Dante Catalfamo
 ;;      soywod <clement.douin@posteo.net>

--- a/himalaya-template.el
+++ b/himalaya-template.el
@@ -1,7 +1,7 @@
 ;;; himalaya-template.el --- Template management of email client Himalaya CLI  -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2021 Dante Catalfamo
-;; Copyright (C) 2022-2023 soywod <clement.douin@posteo.net>
+;; Copyright (C) 2022-2024 soywod <clement.douin@posteo.net>
 
 ;; Author: Dante Catalfamo
 ;;      soywod <clement.douin@posteo.net>

--- a/himalaya-template.el
+++ b/himalaya-template.el
@@ -77,7 +77,7 @@
 
 (defun himalaya--send-template (template callback)
   "Send TEMPLATE."
-  (message "Sending template…")
+  (message "Sending message…")
   (himalaya--run
    callback
    template

--- a/himalaya.el
+++ b/himalaya.el
@@ -1,7 +1,7 @@
 ;;; himalaya.el --- Interface for the email client Himalaya CLI  -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2021 Dante Catalfamo
-;; Copyright (C) 2022-2023 soywod <clement.douin@posteo.net>
+;; Copyright (C) 2022-2024 soywod <clement.douin@posteo.net>
 
 ;; Author: Dante Catalfamo
 ;;      soywod <clement.douin@posteo.net>


### PR DESCRIPTION
Fixes #4.

This PR prepare the code for the next version of the CLI `v1.0.0-beta.4`. The main change so far is the filter and sort envelopes support.

I leave this PR in draft till the new version is released.