### PR TITLE
fix: Disable Rust logging via env

### DIFF
--- a/himalaya-process.el
+++ b/himalaya-process.el
@@ -99,7 +99,8 @@ nil. Signals a Lisp error and displays the output on non-zero exit."
   "Blocking version of 'himalaya--run'."
   (himalaya--clear-io-buffers)
   (with-temp-buffer
-    (let* ((args (list (when himalaya-config-path (list "-c" himalaya-config-path)) "-o" "json" args))
+    (let* ((process-environment (cons "RUST_LOG=off" process-environment))
+           (args (list (when himalaya-config-path (list "-c" himalaya-config-path)) "-o" "json" args))
            (exit-status (apply #'call-process himalaya-executable nil t nil (flatten-list args)))
 	   (output (buffer-string)))
       (unless (eq 0 exit-status)


### PR DESCRIPTION
This was based on @paulvictor's fix[^1]. This may be considered a short-term fix, until work on pimalaya/himalaya#539 is done.

I've used this for the last 3 days with success.

FIXES #27

[^1]: https://github.com/dantecatalfamo/himalaya-emacs/issues/27#issuecomment-2782953637
